### PR TITLE
Added subcommand: build to workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,6 +13,7 @@ jobs:
     uses: AudioKit/ci/.github/workflows/swift_test.yml@main
     with:
       scheme: PianoRoll
+      subcommand: build
       platforms: iOS macOS
       swift-versions: 5.5 5.6
 


### PR DESCRIPTION
This will work until PianoRoll has tests, because it ensures the project can build versus running `swift test` or `xcodebuild test`.