### PR TITLE
Allow grid size and color customisation

### DIFF
--- a/Sources/PianoRoll/PianoRoll.swift
+++ b/Sources/PianoRoll/PianoRoll.swift
@@ -7,19 +7,26 @@ import SwiftUI
 /// Note: Requires macOS 12 / iOS 15 due to SwiftUI bug (crashes in SwiftUI when deleting notes).
 public struct PianoRoll: View {
     @Binding var model: PianoRollModel
-    var gridSize = CGSize(width: 80, height: 40)
-    var noteColor = Color.accentColor
+    var gridSize: CGSize
+    var noteColor: Color
+    var gridColor: Color
 
     /// Initialize PianoRoll with a binding to a model and a color
     /// - Parameters:
     ///   - model: PianoRoll data
     ///   - noteColor: Color to use for the note indicator, defaults to system accent color
-    public init(model: Binding<PianoRollModel>, noteColor: Color = .accentColor) {
+    public init(
+        model: Binding<PianoRollModel>,
+        noteColor: Color = .accentColor,
+        gridSize: CGSize = CGSize(width: 80, height: 40),
+        gridColor: Color = Color(red: 15.0 / 255.0, green: 17.0 / 255.0, blue: 16.0 / 255.0)
+    ) {
         _model = model
         self.noteColor = noteColor
+        self.gridSize = gridSize
+        self.gridColor = gridColor
     }
 
-    let gridColor = Color(red: 15.0 / 255.0, green: 17.0 / 255.0, blue: 16.0 / 255.0)
 
     /// SwiftUI view with grid and ability to add, delete and modify notes
     public var body: some View {


### PR DESCRIPTION
This is to allow library user to customise grid size and color to meet their own app design requirement.

Example of customisation (demo code below, not included in this PR):

```swift
public struct PianoRollDemoView: View {
    public init() {}

    @State var model = PianoRollModel(notes: [
        PianoRollNote(start: 1, length: 2, pitch: 3),
        PianoRollNote(start: 5, length: 1, pitch: 4),
    ], length: 128, height: 128)

    public var body: some View {
        ScrollView([.horizontal, .vertical], showsIndicators: true) {
            PianoRoll(model: $model, noteColor: .cyan, gridSize: .init(width: 100, height: 50), gridColor: .blue)
        }
    }
}
```

![simulator_screenshot_8C0E6946-0B01-432F-AE50-92EC1C0901DC](https://user-images.githubusercontent.com/4270232/197373651-675207a6-d380-47e1-b2b8-ad7ea57fc9fa.png)
