### PR TITLE
Add readOnly mode to PianoRoll

### DIFF
--- a/Sources/PianoRoll/PianoRoll.swift
+++ b/Sources/PianoRoll/PianoRoll.swift
@@ -9,14 +9,20 @@ public struct PianoRoll: View {
     @Binding var model: PianoRollModel
     var gridSize = CGSize(width: 80, height: 40)
     var noteColor = Color.accentColor
+    var readOnly: Bool = false
 
     /// Initialize PianoRoll with a binding to a model and a color
     /// - Parameters:
     ///   - model: PianoRoll data
     ///   - noteColor: Color to use for the note indicator, defaults to system accent color
-    public init(model: Binding<PianoRollModel>, noteColor: Color = .accentColor) {
+    public init(
+        model: Binding<PianoRollModel>,
+        noteColor: Color = .accentColor,
+        readOnly: Bool = false
+    ) {
         _model = model
         self.noteColor = noteColor
+        self.readOnly = readOnly
     }
 
     let gridColor = Color(red: 15.0 / 255.0, green: 17.0 / 255.0, blue: 16.0 / 255.0)
@@ -34,7 +40,7 @@ public struct PianoRoll: View {
                 .stroke(lineWidth: 0.5)
                 .foregroundColor(gridColor)
                 .contentShape(Rectangle())
-                .gesture(TapGesture().sequenced(before: dragGesture))
+                .gesture(readOnly ? nil : TapGesture().sequenced(before: dragGesture))
             ForEach(model.notes) { note in
                 PianoRollNoteView(
                     note: $model.notes[model.notes.firstIndex(of: note)!],
@@ -42,9 +48,11 @@ public struct PianoRoll: View {
                     color: noteColor,
                     sequenceLength: model.length,
                     sequenceHeight: model.height,
-                    isContinuous: true
+                    isContinuous: true,
+                    readOnly: readOnly
                 )
                 .onTapGesture {
+                    if readOnly { return }
                     model.notes.removeAll(where: { $0 == note })
                 }
             }

--- a/Sources/PianoRoll/PianoRoll.swift
+++ b/Sources/PianoRoll/PianoRoll.swift
@@ -11,21 +11,28 @@ public struct PianoRoll: View {
     var noteColor: Color
     var gridColor: Color
     var readOnly: Bool
+    var noteLineOpacity: Double
 
 
     /// Initialize PianoRoll with a binding to a model and a color
     /// - Parameters:
     ///   - model: PianoRoll data
     ///   - noteColor: Color to use for the note indicator, defaults to system accent color
+    ///   - noteLineOpacity: Opacity of the note view vertical black line
+    ///   - gridSize: Size of a grid cell
+    ///   - gridColor: Color of grid
+    ///   - readOnly: Disable addition, modification and deletion of any note in piano roll
     public init(
         model: Binding<PianoRollModel>,
         noteColor: Color = .accentColor,
+        noteLineOpacity: Double = 1,
         gridSize: CGSize = CGSize(width: 80, height: 40),
         gridColor: Color = Color(red: 15.0 / 255.0, green: 17.0 / 255.0, blue: 16.0 / 255.0),
         readOnly: Bool = false
     ) {
         _model = model
         self.noteColor = noteColor
+        self.noteLineOpacity = noteLineOpacity
         self.gridSize = gridSize
         self.gridColor = gridColor
         self.readOnly = readOnly
@@ -54,7 +61,8 @@ public struct PianoRoll: View {
                     sequenceLength: model.length,
                     sequenceHeight: model.height,
                     isContinuous: true,
-                    readOnly: readOnly
+                    readOnly: readOnly,
+                    lineOpacity: noteLineOpacity
                 )
                 .onTapGesture {
                     if readOnly { return }

--- a/Sources/PianoRoll/PianoRoll.swift
+++ b/Sources/PianoRoll/PianoRoll.swift
@@ -7,35 +7,35 @@ import SwiftUI
 /// Note: Requires macOS 12 / iOS 15 due to SwiftUI bug (crashes in SwiftUI when deleting notes).
 public struct PianoRoll: View {
     @Binding var model: PianoRollModel
+    var editable: Bool
+    var gridColor: Color
     var gridSize: CGSize
     var noteColor: Color
-    var gridColor: Color
-    var readOnly: Bool
     var noteLineOpacity: Double
 
 
     /// Initialize PianoRoll with a binding to a model and a color
     /// - Parameters:
+    ///   - editable: Disable edition of any note in piano roll
     ///   - model: PianoRoll data
     ///   - noteColor: Color to use for the note indicator, defaults to system accent color
     ///   - noteLineOpacity: Opacity of the note view vertical black line
-    ///   - gridSize: Size of a grid cell
     ///   - gridColor: Color of grid
-    ///   - readOnly: Disable addition, modification and deletion of any note in piano roll
+    ///   - gridSize: Size of a grid cell
     public init(
+        editable: Bool = true,
         model: Binding<PianoRollModel>,
         noteColor: Color = .accentColor,
         noteLineOpacity: Double = 1,
-        gridSize: CGSize = CGSize(width: 80, height: 40),
         gridColor: Color = Color(red: 15.0 / 255.0, green: 17.0 / 255.0, blue: 16.0 / 255.0),
-        readOnly: Bool = false
+        gridSize: CGSize = CGSize(width: 80, height: 40)
     ) {
         _model = model
         self.noteColor = noteColor
         self.noteLineOpacity = noteLineOpacity
         self.gridSize = gridSize
         self.gridColor = gridColor
-        self.readOnly = readOnly
+        self.editable = editable
     }
 
 
@@ -52,7 +52,7 @@ public struct PianoRoll: View {
                 .stroke(lineWidth: 0.5)
                 .foregroundColor(gridColor)
                 .contentShape(Rectangle())
-                .gesture(readOnly ? nil : TapGesture().sequenced(before: dragGesture))
+                .gesture(editable ? TapGesture().sequenced(before: dragGesture) : nil)
             ForEach(model.notes) { note in
                 PianoRollNoteView(
                     note: $model.notes[model.notes.firstIndex(of: note)!],
@@ -61,11 +61,11 @@ public struct PianoRoll: View {
                     sequenceLength: model.length,
                     sequenceHeight: model.height,
                     isContinuous: true,
-                    readOnly: readOnly,
+                    editable: editable,
                     lineOpacity: noteLineOpacity
                 )
                 .onTapGesture {
-                    if readOnly { return }
+                    guard editable else { return }
                     model.notes.removeAll(where: { $0 == note })
                 }
             }

--- a/Sources/PianoRoll/PianoRollNoteView.swift
+++ b/Sources/PianoRoll/PianoRollNoteView.swift
@@ -27,7 +27,7 @@ struct PianoRollNoteView: View {
     var sequenceLength: Int
     var sequenceHeight: Int
     var isContinuous = false
-    var readOnly: Bool = false
+    var editable: Bool = false
     var lineOpacity: Double = 1
 
     var noteColor: Color {
@@ -116,14 +116,14 @@ struct PianoRollNoteView: View {
                 .foregroundColor(.black)
                 .padding(4)
                 .frame(width: 10)
-                .opacity(lineOpacity)
+                .opacity(editable ? lineOpacity : 0)
         }
             .onHover { over in hovering = over }
             .padding(1) // so we can see consecutive notes
             .frame(width: max(gridSize.width, gridSize.width * CGFloat(note.length) + lengthOffset),
                    height: gridSize.height)
-            .offset( noteOffset(note: startNote ?? note, dragOffset: offset))
-            .gesture(readOnly ? nil : noteDragGesture)
+            .offset(noteOffset(note: startNote ?? note, dragOffset: offset))
+            .gesture(editable ? noteDragGesture : nil)
 
         // Length tab at the end of the note.
         HStack {
@@ -131,7 +131,7 @@ struct PianoRollNoteView: View {
             Rectangle()
                 .foregroundColor(.white.opacity(0.001))
                 .frame(width: gridSize.width * 0.5, height: gridSize.height)
-                .gesture(readOnly ? nil : lengthDragGesture)
+                .gesture(editable ? lengthDragGesture : nil)
         }
         .frame(width: gridSize.width * CGFloat(note.length),
                height: gridSize.height)

--- a/Sources/PianoRoll/PianoRollNoteView.swift
+++ b/Sources/PianoRoll/PianoRollNoteView.swift
@@ -28,6 +28,7 @@ struct PianoRollNoteView: View {
     var sequenceHeight: Int
     var isContinuous = false
     var readOnly: Bool = false
+    var lineOpacity: Double = 1
 
     var noteColor: Color {
         note.color ?? color
@@ -110,7 +111,7 @@ struct PianoRollNoteView: View {
                 .foregroundColor(.black)
                 .padding(4)
                 .frame(width: 10)
-                .opacity(readOnly ? 0 : 1)
+                .opacity(lineOpacity)
         }
             .onHover { over in hovering = over }
             .padding(1) // so we can see consecutive notes

--- a/Sources/PianoRoll/PianoRollNoteView.swift
+++ b/Sources/PianoRoll/PianoRollNoteView.swift
@@ -27,6 +27,7 @@ struct PianoRollNoteView: View {
     var sequenceLength: Int
     var sequenceHeight: Int
     var isContinuous = false
+    var readOnly: Bool = false
 
     func snap(note: PianoRollNote, offset: CGSize, lengthOffset: CGFloat = 0.0) -> PianoRollNote {
         var n = note
@@ -105,13 +106,14 @@ struct PianoRollNoteView: View {
                 .foregroundColor(.black)
                 .padding(4)
                 .frame(width: 10)
+                .opacity(readOnly ? 0 : 1)
         }
             .onHover { over in hovering = over }
             .padding(1) // so we can see consecutive notes
             .frame(width: max(gridSize.width, gridSize.width * CGFloat(note.length) + lengthOffset),
                    height: gridSize.height)
             .offset( noteOffset(note: startNote ?? note, dragOffset: offset))
-            .gesture(noteDragGesture)
+            .gesture(readOnly ? nil : noteDragGesture)
 
         // Length tab at the end of the note.
         HStack {
@@ -119,7 +121,7 @@ struct PianoRollNoteView: View {
             Rectangle()
                 .foregroundColor(.white.opacity(0.001))
                 .frame(width: gridSize.width * 0.5, height: gridSize.height)
-                .gesture(lengthDragGesture)
+                .gesture(readOnly ? nil : lengthDragGesture)
         }
         .frame(width: gridSize.width * CGFloat(note.length),
                height: gridSize.height)


### PR DESCRIPTION
This PR adds `readOnly` mode to `PianoRoll`, which disable adding / editing / removing any note.
User can change black vertical line's opacity using PianoRoll's `noteLineOpacity`.

![simulator_screenshot_1B435FBF-3550-4F79-A9A4-DFBAFFA4ED2C](https://user-images.githubusercontent.com/4270232/197400176-def0c4f6-855d-4ded-bb43-86a585dddb73.png)
