### PR TITLE
Show note text content

### DIFF
--- a/Sources/PianoRoll/PianoRollNote.swift
+++ b/Sources/PianoRoll/PianoRollNote.swift
@@ -9,10 +9,12 @@ public struct PianoRollNote: Equatable, Identifiable {
     ///   - start: The start step
     ///   - length: Duration, measured in steps
     ///   - pitch: Abstract pitch, not MIDI notes.
-    public init(start: Double, length: Double, pitch: Int) {
+    ///   - text: Optional text shown on the note view.
+    public init(start: Double, length: Double, pitch: Int, text: String? = nil) {
         self.start = start
         self.length = length
         self.pitch = pitch
+        self.text = text
     }
 
     /// Unique Identifier
@@ -26,4 +28,7 @@ public struct PianoRollNote: Equatable, Identifiable {
 
     /// Abstract pitch, not MIDI notes.
     var pitch: Int
+
+    /// Optional text shown on the note view
+    var text: String?
 }

--- a/Sources/PianoRoll/PianoRollNoteView.swift
+++ b/Sources/PianoRoll/PianoRollNoteView.swift
@@ -99,8 +99,13 @@ struct PianoRollNoteView: View {
 
         // Main note body.
         ZStack(alignment: .trailing) {
-            Rectangle()
-                .foregroundColor(color.opacity((hovering || offset != .zero || lengthOffset != 0) ? 1.0 : 0.8))
+            ZStack(alignment: .leading) {
+                Rectangle()
+                    .foregroundColor(color.opacity((hovering || offset != .zero || lengthOffset != 0) ? 1.0 : 0.8))
+                Text(note.text ?? "")
+                    .opacity(note.text == nil ? 0 : 1)
+                    .padding(.leading, 5)
+            }
             Rectangle()
                 .foregroundColor(.black)
                 .padding(4)


### PR DESCRIPTION
This PR allows user to define optional note text shown on the note view.

![simulator_screenshot_FAFDE9B0-D862-4C43-B8FD-8ECBE74AD235](https://user-images.githubusercontent.com/4270232/197401079-7492ccf9-1081-4016-92e1-b7d83203a469.png)
