### PR TITLE
Add individual note color

### DIFF
--- a/Sources/PianoRoll/PianoRollNote.swift
+++ b/Sources/PianoRoll/PianoRollNote.swift
@@ -6,10 +6,12 @@ import SwiftUI
 public struct PianoRollNote: Equatable, Identifiable {
     /// Initialize the PianoRollNote with start time, duration, and pitch
     /// - Parameters:
+    ///   - color: Individual note color. It will default to `noteColor` in `PianoRoll` if not set.
     ///   - start: The start step
     ///   - length: Duration, measured in steps
     ///   - pitch: Abstract pitch, not MIDI notes.
-    public init(start: Double, length: Double, pitch: Int) {
+    public init(color: Color? = nil, start: Double, length: Double, pitch: Int) {
+        self.color = color
         self.start = start
         self.length = length
         self.pitch = pitch
@@ -17,6 +19,9 @@ public struct PianoRollNote: Equatable, Identifiable {
 
     /// Unique Identifier
     public var id = UUID()
+
+    /// Individual note color. It will default to `noteColor` in `PianoRoll` if not set.
+    var color: Color?
 
     /// The start step
     var start: Double

--- a/Sources/PianoRoll/PianoRollNoteView.swift
+++ b/Sources/PianoRoll/PianoRollNoteView.swift
@@ -28,6 +28,10 @@ struct PianoRollNoteView: View {
     var sequenceHeight: Int
     var isContinuous = false
 
+    var noteColor: Color {
+        note.color ?? color
+    }
+
     func snap(note: PianoRollNote, offset: CGSize, lengthOffset: CGFloat = 0.0) -> PianoRollNote {
         var n = note
         if isContinuous {
@@ -100,7 +104,7 @@ struct PianoRollNoteView: View {
         // Main note body.
         ZStack(alignment: .trailing) {
             Rectangle()
-                .foregroundColor(color.opacity((hovering || offset != .zero || lengthOffset != 0) ? 1.0 : 0.8))
+                .foregroundColor(noteColor.opacity((hovering || offset != .zero || lengthOffset != 0) ? 1.0 : 0.8))
             Rectangle()
                 .foregroundColor(.black)
                 .padding(4)


### PR DESCRIPTION
This allows user to assign note color to single note. If `color` is not set on a note it will default to `noteColor` defined in `PianoRoll`.

![simulator_screenshot_F061DFF1-2580-4921-9321-53890194ED98](https://user-images.githubusercontent.com/4270232/197401682-629782cb-0e06-43fd-a3cd-c67bc86f2c39.png)
