### PR TITLE
Collect note offset for programmatic scrolling

### DIFF
--- a/Sources/PianoRoll/PianoRollNoteView.swift
+++ b/Sources/PianoRoll/PianoRollNoteView.swift
@@ -110,8 +110,11 @@ struct PianoRollNoteView: View {
             .padding(1) // so we can see consecutive notes
             .frame(width: max(gridSize.width, gridSize.width * CGFloat(note.length) + lengthOffset),
                    height: gridSize.height)
-            .offset( noteOffset(note: startNote ?? note, dragOffset: offset))
+            .offset(noteOffset(note: startNote ?? note, dragOffset: offset))
             .gesture(noteDragGesture)
+            .preference(key: NoteOffsetsKey.self,
+                        value: [NoteOffsetInfo(offset: noteOffset(note: startNote ?? note, dragOffset: offset),
+                                               noteId: note.id)])
 
         // Length tab at the end of the note.
         HStack {

--- a/Sources/PianoRoll/PreferenceKeys.swift
+++ b/Sources/PianoRoll/PreferenceKeys.swift
@@ -1,0 +1,15 @@
+import SwiftUI
+
+/// For accumulating note view offsets.
+public struct NoteOffsetsKey: PreferenceKey {
+    public static var defaultValue: [NoteOffsetInfo] = []
+
+    public static func reduce(value: inout [NoteOffsetInfo], nextValue: () -> [NoteOffsetInfo]) {
+        value.append(contentsOf: nextValue())
+    }
+}
+
+public struct NoteOffsetInfo: Equatable {
+    public var offset: CGSize
+    public var noteId: UUID
+}


### PR DESCRIPTION
This is to enable library user to collect note view offset so that they can programmatically scroll to a note.

I tried vanilla ScrollView and ScrollViewReader, however it failed to scroll to the correct note view with anchor id. Therefore I switched to scroll with offset.

Demo code (not included in the PR as I'm using a 3rd party library [`SolidScroll`](https://github.com/edudnyk/SolidScroll) in order to scroll to certain offset):

```swift
// Copyright AudioKit. All Rights Reserved. Revision History at http://github.com/AudioKit/AudioKitUI/

import PianoRoll
import SwiftUI
import SolidScroll // add https://github.com/edudnyk/SolidScroll package into demo project for this demo to work

public struct PianoRollDemoView: View {
    @State var model: PianoRollModel
    @State var scrollViewProxy: SolidScrollViewProxy?

    let notes = [
        PianoRollNote(start: 0, length: 2, pitch: 100),
        PianoRollNote(start: 4, length: 1, pitch: 120),
    ]
    
    @State var offsetInfos: [NoteOffsetInfo] = []

    public init() {
        self._model = .init(initialValue: .init(notes: notes, length: 128, height: 128))
    }
    
    public var body: some View {
        VStack {
            Button("Scroll") {
                guard let scrollViewProxy = scrollViewProxy, let offset = offsetInfos.first?.offset else { return }
                let contentOffset = CGPoint(x: offset.width, y: offset.height)
                scrollViewProxy.setContentOffset(contentOffset, animated: true, completion: { completed in
                  print("Scrolled via proxy to \(contentOffset)! Completed: \(completed)")
                })
            }
            .padding(.top, 10)
            SolidScrollView([.horizontal, .vertical], showsIndicators: true) {
                PianoRoll(model: $model, noteColor: .cyan)
            }
            .onPreferenceChange(ContainedScrollViewKey.self) {
                scrollViewProxy = $0
            }
            .onPreferenceChange(NoteOffsetsKey.self) {
                offsetInfos = $0
            }
        }
        
    }
}

struct DemoView_Previews: PreviewProvider {
    static var previews: some View {
        PianoRollDemoView()
    }
}
```

https://user-images.githubusercontent.com/4270232/197404948-63b2db0f-5f54-416c-91ff-b25ca51bd321.mp4

