### PR TITLE
Make PianoRollNote properties public

### DIFF
--- a/Sources/PianoRoll/PianoRollNote.swift
+++ b/Sources/PianoRoll/PianoRollNote.swift
@@ -23,17 +23,17 @@ public struct PianoRollNote: Equatable, Identifiable {
     public var id = UUID()
 
     /// Individual note color. It will default to `noteColor` in `PianoRoll` if not set.
-    var color: Color?
+    public var color: Color?
 
     /// The start step
-    var start: Double
+    public var start: Double
 
     /// Duration, measured in steps
-    var length: Double
+    public var length: Double
 
     /// Abstract pitch, not MIDI notes.
-    var pitch: Int
+    public var pitch: Int
 
     /// Optional text shown on the note view
-    var text: String?
+    public var text: String?
 }


### PR DESCRIPTION
As title suggests, publicizing `PianoRollNote` properties. This makes it possible to read / modify these properties programmatically.

An example is setting piano key pressed color and `isActivatedExternally` based on the piano roll note `color`, `start`, `length` and `pitch` when piano roll is being played.

https://user-images.githubusercontent.com/4270232/199256779-7e309578-a0f5-44ed-8804-1b0f803f5bce.mp4

