### PR TITLE
Add vertical layout, fix dragging bug

### DIFF
--- a/Demo/Shared/PianoRollDemoView.swift
+++ b/Demo/Shared/PianoRollDemoView.swift
@@ -13,7 +13,7 @@ public struct PianoRollDemoView: View {
 
     public var body: some View {
         ScrollView([.horizontal, .vertical], showsIndicators: true) {
-            PianoRoll(model: $model, noteColor: .cyan)
+            PianoRoll(model: $model, noteColor: .cyan, layout: .vertical)
         }.background(Color(white: 0.1))
     }
 }

--- a/Sources/PianoRoll/PianoRoll.swift
+++ b/Sources/PianoRoll/PianoRoll.swift
@@ -66,8 +66,8 @@ public struct PianoRoll: View {
                     note = PianoRollNote(start: step, length: 1, pitch: pitch)
                 case .vertical:
                     let step = Double(Int(location.y / gridSize.width))
-                    let pitch = model.height - Int(location.x / gridSize.height)
-                    note = PianoRollNote(start: step, length: 1, pitch: pitch)
+                    let pitch = Int(location.x / gridSize.height)
+                    note = PianoRollNote(start: Double(model.length) - step - 1, length: 1, pitch: pitch + 1)
                 }
                 model.notes.append(note)
             }

--- a/Sources/PianoRoll/PianoRoll.swift
+++ b/Sources/PianoRoll/PianoRoll.swift
@@ -6,13 +6,18 @@ import SwiftUI
 ///
 /// Note: Requires macOS 12 / iOS 15 due to SwiftUI bug (crashes in SwiftUI when deleting notes).
 public struct PianoRoll: View {
+    public enum Layout {
+        case horizontal
+        case vertical
+    }
+
     @Binding var model: PianoRollModel
     var editable: Bool
     var gridColor: Color
     var gridSize: CGSize
     var noteColor: Color
     var noteLineOpacity: Double
-
+    var layout: Layout
 
     /// Initialize PianoRoll with a binding to a model and a color
     /// - Parameters:
@@ -28,7 +33,8 @@ public struct PianoRoll: View {
         noteColor: Color = .accentColor,
         noteLineOpacity: Double = 1,
         gridColor: Color = Color(red: 15.0 / 255.0, green: 17.0 / 255.0, blue: 16.0 / 255.0),
-        gridSize: CGSize = CGSize(width: 80, height: 40)
+        gridSize: CGSize = CGSize(width: 80, height: 40),
+        layout: Layout = .horizontal
     ) {
         _model = model
         self.noteColor = noteColor
@@ -36,41 +42,75 @@ public struct PianoRoll: View {
         self.gridSize = gridSize
         self.gridColor = gridColor
         self.editable = editable
+        self.layout = layout
     }
 
+    private var width: CGFloat {
+        CGFloat(model.length) * gridSize.width
+    }
+
+    private var height: CGFloat {
+        CGFloat(model.height) * gridSize.height
+    }
 
     /// SwiftUI view with grid and ability to add, delete and modify notes
     public var body: some View {
         ZStack(alignment: .topLeading) {
             let dragGesture = DragGesture(minimumDistance: 0).onEnded { value in
                 let location = value.location
-                let step = Double(Int(location.x / gridSize.width))
-                let pitch = model.height - Int(location.y / gridSize.height)
-                model.notes.append(PianoRollNote(start: step, length: 1, pitch: pitch))
+                var note: PianoRollNote
+                switch layout {
+                case .horizontal:
+                    let step = Double(Int(location.x / gridSize.width))
+                    let pitch = model.height - Int(location.y / gridSize.height)
+                    note = PianoRollNote(start: step, length: 1, pitch: pitch)
+                case .vertical:
+                    let step = Double(Int(location.y / gridSize.width))
+                    let pitch = model.height - Int(location.x / gridSize.height)
+                    note = PianoRollNote(start: step, length: 1, pitch: pitch)
+                }
+                model.notes.append(note)
             }
-            PianoRollGrid(gridSize: gridSize, length: model.length, height: model.height)
+            PianoRollGrid(gridSize: gridSize, length: model.length, height: model.height, layout: layout)
                 .stroke(lineWidth: 0.5)
                 .foregroundColor(gridColor)
                 .contentShape(Rectangle())
                 .gesture(editable ? TapGesture().sequenced(before: dragGesture) : nil)
             ForEach(model.notes) { note in
-                PianoRollNoteView(
-                    note: $model.notes[model.notes.firstIndex(of: note)!],
-                    gridSize: gridSize,
-                    color: noteColor,
-                    sequenceLength: model.length,
-                    sequenceHeight: model.height,
-                    isContinuous: true,
-                    editable: editable,
-                    lineOpacity: noteLineOpacity
-                )
-                .onTapGesture {
-                    guard editable else { return }
-                    model.notes.removeAll(where: { $0 == note })
+                switch layout {
+                case .horizontal:
+                    PianoRollNoteView(
+                        note: $model.notes[model.notes.firstIndex(of: note)!],
+                        gridSize: gridSize,
+                        color: noteColor,
+                        sequenceLength: model.length,
+                        sequenceHeight: model.height,
+                        isContinuous: true,
+                        editable: editable,
+                        lineOpacity: noteLineOpacity
+                    ).onTapGesture {
+                        guard editable else { return }
+                        model.notes.removeAll(where: { $0 == note })
+                    }
+
+                case .vertical:
+                    VerticalPianoRollNoteView(
+                        note: $model.notes[model.notes.firstIndex(of: note)!],
+                        gridSize: gridSize,
+                        color: noteColor,
+                        sequenceLength: model.length,
+                        sequenceHeight: model.height,
+                        isContinuous: true,
+                        editable: editable,
+                        lineOpacity: noteLineOpacity
+                    ).onTapGesture {
+                        guard editable else { return }
+                        model.notes.removeAll(where: { $0 == note })
+                    }
                 }
             }
-        }.frame(width: CGFloat(model.length) * gridSize.width,
-                height: CGFloat(model.height) * gridSize.height)
+        }.frame(width: layout == .horizontal ? width : height,
+                height: layout == .horizontal ? height : width)
     }
 }
 

--- a/Sources/PianoRoll/PianoRollGrid.swift
+++ b/Sources/PianoRoll/PianoRollGrid.swift
@@ -10,20 +10,35 @@ struct PianoRollGrid: Shape {
     var gridSize: CGSize
     var length: Int
     var height: Int
+    var layout: PianoRoll.Layout
 
     func path(in rect: CGRect) -> Path {
         let size = rect.size
         var path = Path()
-        for column in 0 ... length {
-            let x = CGFloat(column) * gridSize.width
-            path.move(to: CGPoint(x: x, y: 0))
-            path.addLine(to: CGPoint(x: x, y: size.height))
+
+        func drawHorizontal(count: Int, width: CGFloat) {
+            for column in 0 ... count {
+                let x = CGFloat(column) * width
+                path.move(to: CGPoint(x: x, y: 0))
+                path.addLine(to: CGPoint(x: x, y: size.height))
+            }
         }
 
-        for row in 0 ... height {
-            let y = CGFloat(row) * gridSize.height
-            path.move(to: CGPoint(x: 0, y: y))
-            path.addLine(to: CGPoint(x: size.width, y: y))
+        func drawVertical(count: Int, height: CGFloat) {
+            for row in 0 ... count {
+                let y = CGFloat(row) * height
+                path.move(to: CGPoint(x: 0, y: y))
+                path.addLine(to: CGPoint(x: size.width, y: y))
+            }
+        }
+
+        switch layout {
+        case .horizontal:
+            drawHorizontal(count: length, width: gridSize.width)
+            drawVertical(count: height, height: gridSize.height)
+        case .vertical:
+            drawHorizontal(count: height, width: gridSize.height)
+            drawVertical(count: length, height: gridSize.width)
         }
 
         return path

--- a/Sources/PianoRoll/PianoRollGrid.swift
+++ b/Sources/PianoRoll/PianoRollGrid.swift
@@ -18,17 +18,17 @@ struct PianoRollGrid: Shape {
 
         func drawHorizontal(count: Int, width: CGFloat) {
             for column in 0 ... count {
-                let x = CGFloat(column) * width
-                path.move(to: CGPoint(x: x, y: 0))
-                path.addLine(to: CGPoint(x: x, y: size.height))
+                let anchor = CGFloat(column) * width
+                path.move(to: CGPoint(x: anchor, y: 0))
+                path.addLine(to: CGPoint(x: anchor, y: size.height))
             }
         }
 
         func drawVertical(count: Int, height: CGFloat) {
             for row in 0 ... count {
-                let y = CGFloat(row) * height
-                path.move(to: CGPoint(x: 0, y: y))
-                path.addLine(to: CGPoint(x: size.width, y: y))
+                let anchor = CGFloat(row) * height
+                path.move(to: CGPoint(x: 0, y: anchor))
+                path.addLine(to: CGPoint(x: size.width, y: anchor))
             }
         }
 

--- a/Sources/PianoRoll/VerticalPianoRollNoteView.swift
+++ b/Sources/PianoRoll/VerticalPianoRollNoteView.swift
@@ -8,7 +8,7 @@ import SwiftUI
 ///
 /// With each note as a separate view this might not be suitable for very large sequences, but
 /// it makes it easier to implement.
-struct PianoRollNoteView: View {
+struct VerticalPianoRollNoteView: View {
     @Binding var note: PianoRollNote
     var gridSize: CGSize
     var color: Color
@@ -22,7 +22,7 @@ struct PianoRollNoteView: View {
 
     // Note: using @GestureState instead of @State here fixes a bug where the
     //       lengthOffset could get stuck when inside a ScrollView.
-    @GestureState var lengthOffset: CGFloat = 0
+    @GestureState var heightOffset: CGFloat = 0
 
     var sequenceLength: Int
     var sequenceHeight: Int
@@ -37,13 +37,13 @@ struct PianoRollNoteView: View {
     func snap(note: PianoRollNote, offset: CGSize, lengthOffset: CGFloat = 0.0) -> PianoRollNote {
         var n = note
         if isContinuous {
-            n.start += offset.width / gridSize.width
+            n.start += offset.height / gridSize.width
         } else {
-            n.start += round(offset.width / CGFloat(gridSize.width))
+            n.start += round(offset.height / CGFloat(gridSize.width))
         }
         n.start = max(0, n.start)
         n.start = min(Double(sequenceLength - 1), n.start)
-        n.pitch -= Int(round(offset.height / CGFloat(gridSize.height)))
+        n.pitch -= Int(round(offset.width / CGFloat(gridSize.height)))
         n.pitch = max(1, n.pitch)
         n.pitch = min(sequenceHeight, n.pitch)
         if isContinuous {
@@ -58,8 +58,8 @@ struct PianoRollNoteView: View {
     }
 
     func noteOffset(note: PianoRollNote, dragOffset: CGSize = .zero) -> CGSize {
-        CGSize(width: gridSize.width * CGFloat(note.start) + dragOffset.width,
-               height: gridSize.height * CGFloat(sequenceHeight - note.pitch) + dragOffset.height)
+        CGSize(width: gridSize.height * CGFloat(sequenceHeight - note.pitch) + dragOffset.width,
+               height: gridSize.width * CGFloat(note.start) + dragOffset.height)
     }
 
     var body: some View {
@@ -67,8 +67,8 @@ struct PianoRollNoteView: View {
         if offset != CGSize.zero {
             Rectangle()
                 .foregroundColor(.black.opacity(0.2))
-                .frame(width: gridSize.width * CGFloat(note.length),
-                       height: gridSize.height)
+                .frame(width: gridSize.height,
+                       height: gridSize.width * CGFloat(note.length))
                 .offset(noteOffset(note: note))
                 .zIndex(-1)
         }
@@ -95,33 +95,33 @@ struct PianoRollNoteView: View {
                 }
             }
 
-        let lengthDragGesture = DragGesture(minimumDistance: minimumDistance)
-            .updating($lengthOffset) { value, state, _ in
-                state = value.translation.width
+        let heightDragGesture = DragGesture(minimumDistance: minimumDistance)
+            .updating($heightOffset) { value, state, _ in
+                state = value.translation.height
             }
             .onEnded { value in
-                note = snap(note: note, offset: CGSize.zero, lengthOffset: value.translation.width)
+                note = snap(note: note, offset: CGSize.zero, lengthOffset: value.translation.height)
             }
 
         // Main note body.
-        ZStack(alignment: .trailing) {
-            ZStack(alignment: .leading) {
+        ZStack(alignment: .bottom) {
+            ZStack(alignment: .bottom) {
                 Rectangle()
-                    .foregroundColor(noteColor.opacity((hovering || offset != .zero || lengthOffset != 0) ? 1.0 : 0.8))
+                    .foregroundColor(noteColor.opacity((hovering || offset != .zero || heightOffset != 0) ? 1.0 : 0.8))
                 Text(note.text ?? "")
                     .opacity(note.text == nil ? 0 : 1)
-                    .padding(.leading, 5)
+                    .padding(.bottom, 5)
             }
             Rectangle()
                 .foregroundColor(.black)
                 .padding(4)
-                .frame(width: 10)
+                .frame(height: 10)
                 .opacity(editable ? lineOpacity : 0)
         }
             .onHover { over in hovering = over }
             .padding(1) // so we can see consecutive notes
-            .frame(width: max(gridSize.width, gridSize.width * CGFloat(note.length) + lengthOffset),
-                   height: gridSize.height)
+            .frame(width: gridSize.height,
+                   height: max(gridSize.width, gridSize.width * CGFloat(note.length) + heightOffset))
             .offset(noteOffset(note: startNote ?? note, dragOffset: offset))
             .gesture(editable ? noteDragGesture : nil)
             .preference(key: NoteOffsetsKey.self,
@@ -129,15 +129,16 @@ struct PianoRollNoteView: View {
                                                noteId: note.id)])
 
         // Length tab at the end of the note.
-        HStack {
+        VStack {
             Spacer()
             Rectangle()
-                .foregroundColor(.white.opacity(0.001))
-                .frame(width: gridSize.width * 0.5, height: gridSize.height)
-                .gesture(editable ? lengthDragGesture : nil)
+                .foregroundColor(.green.opacity(0.5))
+                .frame(width: gridSize.height, height: gridSize.width * 0.5)
+                .gesture(editable ? heightDragGesture : nil)
+
         }
-        .frame(width: gridSize.width * CGFloat(note.length),
-               height: gridSize.height)
+        .frame(width: gridSize.height,
+               height: gridSize.width * CGFloat(note.length))
         .offset(noteOffset(note: note, dragOffset: offset))
     }
 }

--- a/Sources/PianoRoll/VerticalPianoRollNoteView.swift
+++ b/Sources/PianoRoll/VerticalPianoRollNoteView.swift
@@ -41,16 +41,17 @@ struct VerticalPianoRollNoteView: View {
         } else {
             n.start += round(offset.height / CGFloat(gridSize.width))
         }
-        n.start = max(0, n.start)
-        n.start = min(Double(sequenceLength - 1), n.start)
         n.pitch -= Int(round(offset.width / CGFloat(gridSize.height)))
         n.pitch = max(1, n.pitch)
         n.pitch = min(sequenceHeight, n.pitch)
         if isContinuous {
             n.length += lengthOffset / gridSize.width
+            n.start -= lengthOffset / gridSize.width
         } else {
             n.length += round(lengthOffset / gridSize.width)
         }
+        n.start = max(0, n.start)
+        n.start = min(Double(sequenceLength - 1), n.start)
         n.length = max(1, n.length)
         n.length = min(Double(sequenceLength), n.length)
         n.length = min(Double(sequenceLength) - n.start, n.length)
@@ -58,8 +59,8 @@ struct VerticalPianoRollNoteView: View {
     }
 
     func noteOffset(note: PianoRollNote, dragOffset: CGSize = .zero) -> CGSize {
-        CGSize(width: gridSize.height * CGFloat(sequenceHeight - note.pitch) + dragOffset.width,
-               height: gridSize.width * CGFloat(note.start) + dragOffset.height)
+        CGSize(width: gridSize.height * CGFloat(note.pitch - 1) + dragOffset.width,
+               height: gridSize.width * CGFloat(Double(sequenceLength) - note.start - note.length) + dragOffset.height)
     }
 
     var body: some View {
@@ -91,7 +92,10 @@ struct VerticalPianoRollNoteView: View {
             }
             .onChanged { value in
                 if let startNote = startNote {
-                    note = snap(note: startNote, offset: value.translation)
+                    note = snap(
+                        note: startNote,
+                        offset: .init(width: -value.translation.width, height: -value.translation.height)
+                    )
                 }
             }
 

--- a/Sources/PianoRoll/VerticalPianoRollNoteView.swift
+++ b/Sources/PianoRoll/VerticalPianoRollNoteView.swift
@@ -35,27 +35,27 @@ struct VerticalPianoRollNoteView: View {
     }
 
     func snap(note: PianoRollNote, offset: CGSize, lengthOffset: CGFloat = 0.0) -> PianoRollNote {
-        var n = note
+        var note = note
         if isContinuous {
-            n.start += offset.height / gridSize.width
+            note.start += offset.height / gridSize.width
         } else {
-            n.start += round(offset.height / CGFloat(gridSize.width))
+            note.start += round(offset.height / CGFloat(gridSize.width))
         }
-        n.pitch -= Int(round(offset.width / CGFloat(gridSize.height)))
-        n.pitch = max(1, n.pitch)
-        n.pitch = min(sequenceHeight, n.pitch)
+        note.pitch -= Int(round(offset.width / CGFloat(gridSize.height)))
+        note.pitch = max(1, note.pitch)
+        note.pitch = min(sequenceHeight, note.pitch)
         if isContinuous {
-            n.length += lengthOffset / gridSize.width
-            n.start -= lengthOffset / gridSize.width
+            note.length += lengthOffset / gridSize.width
+            note.start -= lengthOffset / gridSize.width
         } else {
-            n.length += round(lengthOffset / gridSize.width)
+            note.length += round(lengthOffset / gridSize.width)
         }
-        n.start = max(0, n.start)
-        n.start = min(Double(sequenceLength - 1), n.start)
-        n.length = max(1, n.length)
-        n.length = min(Double(sequenceLength), n.length)
-        n.length = min(Double(sequenceLength) - n.start, n.length)
-        return n
+        note.start = max(0, note.start)
+        note.start = min(Double(sequenceLength - 1), note.start)
+        note.length = max(1, note.length)
+        note.length = min(Double(sequenceLength), note.length)
+        note.length = min(Double(sequenceLength) - note.start, note.length)
+        return note
     }
 
     func noteOffset(note: PianoRollNote, dragOffset: CGSize = .zero) -> CGSize {
@@ -85,7 +85,7 @@ struct VerticalPianoRollNoteView: View {
             .updating($offset) { value, state, _ in
                 state = value.translation
             }
-            .updating($startNote){ value, state, _ in
+            .updating($startNote) { _, state, _ in
                 if state == nil {
                     state = note
                 }
@@ -136,7 +136,7 @@ struct VerticalPianoRollNoteView: View {
         VStack {
             Spacer()
             Rectangle()
-                .foregroundColor(.green.opacity(0.5))
+                .foregroundColor(.white.opacity(0.001))
                 .frame(width: gridSize.height, height: gridSize.width * 0.5)
                 .gesture(editable ? heightDragGesture : nil)
 


### PR DESCRIPTION
This PR allows user to choose vertical layout of piano roll.

https://user-images.githubusercontent.com/4270232/199546700-99a565be-e7eb-4a6b-96c9-02e8f37ba774.mp4

It also fixes a bug that `snap` function calculates the pitch wrongly because pitch is not 0 indexed.

Before:

https://user-images.githubusercontent.com/4270232/199544195-2471c0e1-6f26-4c5c-ace2-80afc88fb588.mp4

After:

https://user-images.githubusercontent.com/4270232/199544215-9fcb31e1-37b5-424a-a816-5a6eef3d2851.mp4


