### PR TITLE
Publicize PianoRollModel properties

### DIFF
--- a/Sources/PianoRoll/PianoRollModel.swift
+++ b/Sources/PianoRoll/PianoRollModel.swift
@@ -19,11 +19,11 @@ public struct PianoRollModel: Equatable {
     }
 
     /// The sequence being edited
-    var notes: [PianoRollNote]
+    public var notes: [PianoRollNote]
 
     /// Duration in steps
-    var length: Int
+    public var length: Int
 
     /// The number of pitches represented
-    var height: Int
+    public var height: Int
 }


### PR DESCRIPTION
As title suggests, make notes, length, height public. Sometimes we want to use these properties for calculation e.g. accompanying keyboard height based on piano roll height.